### PR TITLE
Fix failing test_styles tests.

### DIFF
--- a/tests/test_styles/test_style_blank.py
+++ b/tests/test_styles/test_style_blank.py
@@ -1,8 +1,13 @@
 import sys
+
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx_testing import with_app
 
 @with_app(buildername='html', srcdir='doc_test/doc_style_blank')
 def test_doc_style_blank(app, status, warning):
+    # css_files is not cleared between test runs so css files get
+    # progressively added.  This forces it to clear before re-building
+    del StandaloneHTMLBuilder.css_files[:]
     app.build()
     html = (app.outdir / 'index.html').read_text()
     assert 'blank.css' in html

--- a/tests/test_styles/test_style_custom.py
+++ b/tests/test_styles/test_style_custom.py
@@ -1,8 +1,12 @@
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx_testing import with_app
 
 
 @with_app(buildername='html', srcdir='doc_test/doc_style_custom')
 def test_doc_style_custom(app, status, warning):
+    # css_files is not cleared between test runs so css files get
+    # progressively added.  This forces it to clear before re-building
+    del StandaloneHTMLBuilder.css_files[:]
     app.build()
     html = (app.outdir / 'index.html').read_text()
     assert 'blank.css' not in html

--- a/tests/test_styles/test_style_modern.py
+++ b/tests/test_styles/test_style_modern.py
@@ -1,8 +1,12 @@
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx_testing import with_app
 
 
 @with_app(buildername='html', srcdir='doc_test/doc_style_modern')
 def test_doc_style_modern(app, status, warning):
+    # css_files is not cleared between test runs so css files get
+    # progressively added.  This forces it to clear before re-building
+    del StandaloneHTMLBuilder.css_files[:]
     app.build()
     html = (app.outdir / 'index.html').read_text()
     assert 'blank.css' not in html

--- a/tests/test_styles/test_style_unknown.py
+++ b/tests/test_styles/test_style_unknown.py
@@ -1,8 +1,12 @@
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx_testing import with_app
 
 
 @with_app(buildername='html', srcdir='doc_test/doc_style_unknown')
 def test_doc_style_unknown(app, status, warning):
+    # css_files is not cleared between test runs so css files get
+    # progressively added.  This forces it to clear before re-building
+    del StandaloneHTMLBuilder.css_files[:]
     app.build()
     html = (app.outdir / 'index.html').read_text()
     assert 'blank.css' in html


### PR DESCRIPTION
Thanks for contributing this library.  We're exploring using it for some work on the Open Network Automation Platform (ONAP). 

While attempting to run the test suite on my machine using tox, the first test_styles test case would pass, but then all subsequent test cases would fail.   I discovered the the css files associated with the StandaloneHTMLBuilder were not being reset between tests.  

I made the following tweak as a workaround and they are now passing.