### PR TITLE
Fixes #63. Removing two hot spot performance issues related to adding sections and setting the link_backs.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+
+0.2.4
+-----
+ * Bugfix: Fixed performance issue (`#63 <https://github.com/useblocks/sphinxcontrib-needs/issues/63>`_ )
+
 0.2.3
 -----
  * Improvement: Titles can now be made optional.  See :ref:`needs_title_optional`. (`#49 <https://github.com/useblocks/sphinxcontrib-needs/issues/49>`_)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,9 +39,9 @@ sys.path.insert(0, os.path.abspath('../sphinxcontrib'))
 # built documents.
 #
 # The short X.Y version.
-version = '0.2.3'
+version = '0.2.4'
 # The full version, including alpha/beta/rc tags.
-release = '0.2.3'
+release = '0.2.4'
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requires = ['Sphinx', 'six']
 setup(
     name='sphinxcontrib-needs',
     # If you raise, think about versions in conf.py and needs.py!!!
-    version='0.2.3',
+    version='0.2.4',
     url='http://github.com/useblocks/sphinxcontrib-needs',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-needs',
     license='MIT',


### PR DESCRIPTION
This resolves two hot spots.  

The major one was in the add_sections code that I added.  This had terrible performance for larger documents as it was rendering each multiple times for every need in order to extract the titles.  With this fix, we only render only a single child node to get the section title.  This was taking 5+ minutes on a sample doc, and I dropped it to ~20s.  

I also fixed another hotspot in the ``need.process_need_nodes`` method.  This was an n^2 algorithm that was going through all needs twice in a nested loop to establish the link_backs.  I replaced it with a single pass through the needs, and then just a dict lookup to the part need to update ``links_back``.  In my sample doc, this dropped the time spent in this method from 4.2s to 0.014s.

If you're good with these changes, would you mind releasing a new version of the extension?  This issue was bad enough that our build was taking over an hour (very large doc :) ).  I think you'll see some modest performance gains across the board though.

NOTE: This patch also saves the current section name as section_name alongside
the existing list of sections.  This enables section_name to be used
in a needtable. 