### PR TITLE
Enable sorting on arbitrary numerical attributes

### DIFF
--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -112,7 +112,7 @@ For **:types:** the type itself or the human-readable type-title can be used as 
 
 sort_by
 ~~~~~~~
-Sorts the result list. Allowed values are ``id`` and ``status``
+Sorts the result list. Allowed values are ``status`` or any alphanumerical property.
 
 .. container:: toggle
 

--- a/sphinxcontrib/needs/directives/needfilter.py
+++ b/sphinxcontrib/needs/directives/needfilter.py
@@ -142,13 +142,6 @@ def process_needfilters(app, doctree, fromdocname):
             content += tgroup
 
         all_needs = list(all_needs.values())
-
-        if current_needfilter["sort_by"] is not None:
-            if current_needfilter["sort_by"] == "id":
-                all_needs = sorted(all_needs, key=lambda node: node["id"])
-            elif current_needfilter["sort_by"] == "status":
-                all_needs = sorted(all_needs, key=status_sorter)
-
         found_needs = procces_filters(all_needs, current_needfilter)
 
         line_block = nodes.line_block()

--- a/sphinxcontrib/needs/directives/needflow.py
+++ b/sphinxcontrib/needs/directives/needflow.py
@@ -113,13 +113,6 @@ def process_needflow(app, doctree, fromdocname):
         puml_connections = ""
 
         all_needs = list(all_needs.values())
-
-        if current_needflow["sort_by"] is not None:
-            if current_needflow["sort_by"] == "id":
-                all_needs = sorted(all_needs, key=lambda node: node["id"])
-            elif current_needflow["sort_by"] == "status":
-                all_needs = sorted(all_needs, key=status_sorter)
-
         found_needs = procces_filters(all_needs, current_needflow)
 
         for need_info in found_needs:

--- a/sphinxcontrib/needs/directives/needlist.py
+++ b/sphinxcontrib/needs/directives/needlist.py
@@ -90,13 +90,6 @@ def process_needlist(app, doctree, fromdocname):
         all_needs = env.needs_all_needs
         content = []
         all_needs = list(all_needs.values())
-
-        if current_needfilter["sort_by"] is not None:
-            if current_needfilter["sort_by"] == "id":
-                all_needs = sorted(all_needs, key=lambda node: node["id"])
-            elif current_needfilter["sort_by"] == "status":
-                all_needs = sorted(all_needs, key=status_sorter)
-
         found_needs = procces_filters(all_needs, current_needfilter)
 
         line_block = nodes.line_block()

--- a/sphinxcontrib/needs/directives/needtable.py
+++ b/sphinxcontrib/needs/directives/needtable.py
@@ -135,12 +135,6 @@ def process_needtables(app, doctree, fromdocname):
 
         all_needs = list(all_needs.values())
 
-        if current_needtable["sort_by"] is not None:
-            if current_needtable["sort_by"] == "id":
-                all_needs = sorted(all_needs, key=lambda node: node["id"])
-            elif current_needtable["sort_by"] == "status":
-                all_needs = sorted(all_needs, key=status_sorter)
-
         # Perform filtering of needs
         found_needs = procces_filters(all_needs, current_needtable)
 

--- a/sphinxcontrib/needs/filter_common.py
+++ b/sphinxcontrib/needs/filter_common.py
@@ -19,14 +19,13 @@ else:
 
 
 class FilterBase(Directive):
-    def sort_by(argument):
-        return directives.choice(argument, ("status", "id"))
-
-    base_option_spec = {'status': directives.unchanged_required,
-                        'tags': directives.unchanged_required,
-                        'types': directives.unchanged_required,
-                        'filter': directives.unchanged_required,
-                        'sort_by': sort_by}
+    base_option_spec = {
+        "status": directives.unchanged_required,
+        "tags": directives.unchanged_required,
+        "types": directives.unchanged_required,
+        "filter": directives.unchanged_required,
+        "sort_by": directives.unchanged,
+    }
 
     def collect_filter_attributes(self):
         tags = str(self.options.get("tags", ""))
@@ -75,11 +74,18 @@ def procces_filters(all_needs, current_needlist):
     :return: list of needs, which passed the filters
     """
 
-    if current_needlist["sort_by"] is not None:
-        if current_needlist["sort_by"] == "id":
-            all_needs = sorted(all_needs, key=lambda node: node["id"])
-        elif current_needlist["sort_by"] == "status":
+    sort_key = current_needlist["sort_by"]
+    if sort_key is not None:
+        if sort_key == "status":
             all_needs = sorted(all_needs, key=status_sorter)
+        else:
+            try:
+                sorted_needs = sorted(all_needs, key=lambda node: node[sort_key])
+                all_needs = sorted_needs
+            except Exception as e:
+                logger.warning(
+                    "Sorting parameter {0} not valid: Error: {1}".format(sort_key, e)
+                )
 
     found_needs_by_options = []
 


### PR DESCRIPTION
I was working on a project where we wanted to sort needs in a table by a `priority` attribute, but the library only supported sorting by `id` or `status` as far as we could tell. This pull request enables sorting on any alphanumeric attribute. It also removes sorting code that was duplicated between the files `filter_common.py` and `needtable.py` and friends.