### PR TITLE
Add parameter exclude parameter to meta_links_all

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 0.5.2 (not released yet)
 ------------------------
 * Improvement: ``Sphinx-Needs`` configuration gets checked before build. (`#118 <https://github.com/useblocks/sphinxcontrib-needs/issues/118>`_)
+* Improvement: ``meta_links_all`` :ref:`layout function <layout_functions>` now supports an exclude parameter
 * Bugfix: :ref:`needs_global_options` handles None values correctly. ``style`` can now be set.
 * Bugfix: :ref:`needs_title_from_content` takes ``\n`` and ``.`` as delimiter.
 * Bugfix: Setting css-attribute ``white-space: normal`` for all need-tables, which is set badly in some sphinx-themes.

--- a/docs/layout_styles.rst
+++ b/docs/layout_styles.rst
@@ -370,7 +370,7 @@ Available layout functions are:
 
 .. autofunction:: sphinxcontrib.needs.layout.LayoutHandler.meta_links(name, incoming=False)
 
-.. autofunction:: sphinxcontrib.needs.layout.LayoutHandler.meta_links_all(prefix='', postfix='')
+.. autofunction:: sphinxcontrib.needs.layout.LayoutHandler.meta_links_all(prefix='', postfix='', exclude=None)
 
 .. autofunction:: sphinxcontrib.needs.layout.LayoutHandler.image(url, height=None, width=None, align=None, no_link=False)
 

--- a/sphinxcontrib/needs/layout.py
+++ b/sphinxcontrib/needs/layout.py
@@ -620,18 +620,21 @@ class LayoutHandler:
         data_container.append(node_links)
         return data_container
 
-    def meta_links_all(self, prefix='', postfix=''):
+    def meta_links_all(self, prefix='', postfix='', exclude=None):
         """
-        Documents all used link types in the current link automatically.
+        Documents all used link types for the current need automatically.
 
         :param prefix:  prefix string
         :param postfix:  postfix string
+        :param exclude:  list of extra link type names, which are excluded from output
         :return: docutils nodes
         """
+        if exclude is None:
+            exclude = []
         data_container = []
         for link_type in self.app.config.needs_extra_links:
             type_key = link_type['option']
-            if self.need[type_key] is not None and len(self.need[type_key]) > 0:
+            if self.need[type_key] is not None and len(self.need[type_key]) > 0 and type_key not in exclude:
                 outgoing_line = nodes.line()
                 outgoing_label = prefix + '{}:'.format(link_type['outgoing']) + postfix + ' '
                 outgoing_line += self._parse(outgoing_label)
@@ -639,7 +642,7 @@ class LayoutHandler:
                 data_container.append(outgoing_line)
 
             type_key = link_type['option'] + '_back'
-            if self.need[type_key] is not None and len(self.need[type_key]) > 0:
+            if self.need[type_key] is not None and len(self.need[type_key]) > 0 and type_key not in exclude:
                 incoming_line = nodes.line()
                 incoming_label = prefix + '{}:'.format(link_type['incoming']) + postfix + ' '
                 incoming_line += self._parse(incoming_label)


### PR DESCRIPTION
I added a new parameter `exclude` to the layout function `meta_links_all`. Usecase is to have all links documented excluding an unwanted subset.

Documentation and release notes got also updated.