### PR TITLE
Bugfix in meta_all for unwanted updates to INTERNALS global variable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 * Bugfix: :ref:`needs_title_from_content` takes ``\n`` and ``.`` as delimiter.
 * Bugfix: Setting css-attribute ``white-space: normal`` for all need-tables, which is set badly in some sphinx-themes.
   (Yes, I'm looking at you *ReadTheDocs theme*...)
+* Bugfix: ``meta_all`` :ref:`layout function <layout_functions>` also outputs extra links and the `no_links`
+  parameter now works as expected
 
 0.5.1
 -----

--- a/sphinxcontrib/needs/layout.py
+++ b/sphinxcontrib/needs/layout.py
@@ -559,7 +559,7 @@ class LayoutHandler:
         :param show_empty: If true, also need data with no value will be printed. Mostly useful for debugging.
         :return: docutils nodes
         """
-        default_excludes = INTERNALS
+        default_excludes = INTERNALS.copy()
 
         if exclude is None or not isinstance(exclude, list):
             if defaults:


### PR DESCRIPTION
`meta_all` never had the links as part of its output. This was due to the fact that the `INTERNALS` variables was assigned to the local variable `default_excludes`. `exclude` was then assigned to  `default_excludes` and got modified later. As only references got passed here, the original `INTERNALS` variable got changed on every call to `meta_all` function which led to a couple of hundred entries.
Now the `INTERNALS` variable gets copied using  `INTERNALS.copy()` so a new list instance gets created.

I tested locally and it works now. Also the `no_links` option works now.
Changelog also got updated with the bugfix.