### PR TITLE
Added .venv and .envrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+.venv
+.envrc
 *.pyc
 *.egg-info
 *egg-info/


### PR DESCRIPTION
.venv is one of the default local virtual environment names
.envrc is the default direnv configuration