### PR TITLE
cross references in multiple latexfiles

### DIFF
--- a/sphinxcontrib/needs/directives/needlist.py
+++ b/sphinxcontrib/needs/directives/needlist.py
@@ -108,9 +108,12 @@ def process_needlist(app, doctree, fromdocname):
             if not need_info["hide"]:
                 ref = nodes.reference('', '')
                 ref['refdocname'] = need_info['docname']
-                ref['refuri'] = app.builder.get_relative_uri(
-                    fromdocname, need_info['docname'])
-                ref['refuri'] += '#' + need_info['target_node']['refid']
+                try: 
+                    ref['refuri'] = app.builder.get_relative_uri(
+                        fromdocname, need_info['docname'])
+                    ref['refuri'] += '#' + need_info['target_node']['refid']
+                except:
+                    pass
                 ref.append(title)
                 para += ref
             else:

--- a/sphinxcontrib/needs/directives/needtable.py
+++ b/sphinxcontrib/needs/directives/needtable.py
@@ -184,6 +184,7 @@ def process_needtables(app, doctree, fromdocname):
         found_needs.sort(key=get_sorter(current_needtable['sort']))
 
         for need_info in found_needs:
+            make_ref = True
             style_row = check_and_get_content(current_needtable['style_row'], need_info, env)
             style_row = style_row.replace(' ', '_')  # Replace whitespaces with _ to get valid css name
 
@@ -199,8 +200,13 @@ def process_needtables(app, doctree, fromdocname):
 
             for col in current_needtable["columns"]:
                 if col == "ID":
-                    row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, "id", make_ref=True,
-                                         prefix=prefix)
+                    try:
+                        row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, "id", make_ref=make_ref,
+                                             prefix=prefix)
+                    except:
+                        make_ref=False
+                        row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, "id", make_ref=make_ref,
+                                             prefix=prefix)                        
                 elif col == "TITLE":
                     row += row_col_maker(
                         app, fromdocname, env.needs_all_needs, temp_need, "title",
@@ -209,10 +215,10 @@ def process_needtables(app, doctree, fromdocname):
                     link_type = link_type_list[col]
                     if col == 'INCOMING' or col == link_type['option'].upper() + '_BACK' or col == link_type['incoming'].upper():
                         row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need,
-                                             link_type['option'] + '_back', ref_lookup=True)
+                                             link_type['option'] + '_back', ref_lookup=make_ref)
                     else:
                         row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need,
-                                             link_type['option'], ref_lookup=True)
+                                             link_type['option'], ref_lookup=make_ref)
                 else:
                     row += row_col_maker(app, fromdocname, env.needs_all_needs, temp_need, col.lower())
             tbody += row


### PR DESCRIPTION
(This is my first attempt at any sort of pull request on github - let me know if there is more information needed)

I am building a Software Requirements Specification and Software Test Report in separate PDFs with the following in my `conf.py`:

```python
latex_documents = [
  ('software_requirements_specification', 'SRS.tex', 'Software Requirements Specification',
   'myname', 'manual'),
  ('software_test_report', 'STR.tex', 'Software Test Report',
   'myname', 'manual')]
```

When rendering the individual `.tex` files, cross references from needs listed in `STR.tex` cannot be placed to their origin back in `SRS.tex` -- leading to a "Fatal - doctree not resolved" type of error.

With these changes, the following directives in the software_test_report.rst`  work as expected.  Namely, they create a list/table/link back to the need specified in the software_requirement_specification.  When rendering as an html, the list/table/link cross references work correctly.  When rending as latex, the list/table/link render as plain text (without the fatal error).

```rst

.. needtable::
   style: table

.. needlist::

see :need:`REQ_000`
```



