### PR TITLE
refactor sphinxcontrib.needs.api.need

### DIFF
--- a/sphinxcontrib/needs/api/need.py
+++ b/sphinxcontrib/needs/api/need.py
@@ -1,13 +1,17 @@
 import hashlib
 import os
 import re
+from typing import List, Optional
 
 from docutils import nodes
+from docutils.nodes import Node
 from docutils.statemachine import ViewList
 from jinja2 import Template
+from sphinx.application import Sphinx
 from sphinx.util.nodes import nested_parse_with_titles
 
 import sphinxcontrib.needs.directives.need
+from sphinxcontrib.needs import utils
 from sphinxcontrib.needs.api.exceptions import (
     NeedsDuplicatedId,
     NeedsInvalidException,
@@ -24,18 +28,77 @@ from sphinxcontrib.needs.roles.need_part import find_parts, update_need_with_par
 logger = get_logger(__name__)
 
 
-def add_need(app, state, docname, lineno, need_type, title, id=None, content="", status=None, tags=None,
-             links_string=None, hide=False, hide_tags=False, hide_status=False, collapse=None, style=None,
-             layout=None, template=None, pre_template=None, post_template=None, **kwargs):
+class NeedType:
+    def __init__(self, directive: str, name: str, prefix: str, color, style):
+        self.directive = directive
+        self.name = name
+        self.prefix = prefix
+        self.color = color
+        self.style = style
+
+
+def split_tags(
+    tags_string: Optional[str], need_id: str, allowed_tags: Optional[List[str]]
+) -> List[str]:
+
+    if not tags_string:
+        return []
+
+    def is_valid(tag: str) -> bool:
+        if len(tag) == 0 or tag.isspace():
+            logger.warning(
+                "Scruffy tag definition found in need {}. "
+                "Defined tag contains spaces only.".format(need_id)
+            )
+            return False
+
+        if allowed_tags and tag not in allowed_tags:
+            raise NeedsTagNotAllowed(
+                "Tag {0} of need id {1} is not allowed "
+                "by config value 'needs_tags'.".format(tag, need_id)
+            )
+
+        return True
+
+    raw_tags = (tag.strip() for tag in re.split(";|,", tags_string))
+    tags = filter(is_valid, raw_tags)
+
+    return utils.fix_list_dyn_func(tags)
+
+
+def add_need(
+    app: Sphinx,
+    state,
+    docname,
+    lineno: int,
+    need_type: str,
+    title: str,
+    id: Optional[str] = None,
+    content="",
+    status=None,
+    tags: Optional[str] = None,
+    links_string: Optional[str] = None,
+    hide=False,
+    hide_tags=False,
+    hide_status=False,
+    collapse=None,
+    style=None,
+    layout=None,
+    template=None,
+    pre_template=None,
+    post_template=None,
+    **kwargs
+) -> List[Node]:
     """
     Creates a new need and returns its node.
 
-    ``add_need`` allows to create needs programmatically and use its returned node to be integrated in any
-    docutils based structure.
+    ``add_need`` allows to create needs programmatically and use its returned node to
+    be integrated in any docutils based structure.
 
-    ``kwags`` can contain options defined in ``needs_extra_options`` and ``needs_extra_links``.
-    If an entry is found in ``kwags``, which *is not* specified in the configuration or registered e.g. via
-    ``add_extra_option``, an exception is raised.
+    ``kwargs`` can contain options defined in ``needs_extra_options`` and
+    ``needs_extra_links``. If an entry is found in ``kwargs``, which *is not* specified
+    in the configuration or registered e.g. via ``add_extra_option``, an exception is
+    raised.
 
     **Usage**:
 
@@ -55,8 +118,8 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
 
                 docname = self.state.document.settings.env.docname
 
-                # All needed sphinx-internal information we can take from our current directive class.
-                # e..g app, state, lineno
+                # All needed sphinx-internal information we can take from our current
+                # directive class. e.g app, state, lineno
                 main_section += add_need(self.env.app, self.state, docname, self.lineno,
                                          need_type="req", title="my title", id="ID_001"
                                          content=self.content)
@@ -86,97 +149,92 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
     :param pre_template: Template name to use for content added before need
     :param post_template: Template name to use for the content added after need
 
-    :return: node
+    :return: list[Node]
     """
-    #############################################################################################
+    ####################################################################################
     # Get environment
-    #############################################################################################
+    ####################################################################################
     env = app.env
-    types = env.app.config.needs_types
-    type_name = ""
-    type_prefix = ""
-    type_color = ""
-    type_style = ""
-    found = False
-    for ntype in types:
-        if ntype["directive"] == need_type:
-            type_name = ntype["title"]
-            type_prefix = ntype["prefix"]
-            type_color = ntype["color"]
-            type_style = ntype["style"]
-            found = True
-            break
-    if not found:
-        # This should never happen. But it may happen, if Sphinx is called multiples times
-        # inside one ongoing python process.
-        # In this case the configuration from a prior sphinx run may be active, which has registered a directive,
-        # which is reused inside a current document, but no type was defined for the current run...
+    config = app.config
+
+    type_info = next(
+        (t for t in config.needs_types if t["directive"] == need_type), None
+    )
+
+    if type_info is None:
+        # This should never happen. But it may happen, if Sphinx is called multiples
+        # times inside one ongoing python process. In this case the configuration from
+        # a prior sphinx run may be active, which has registered a directive, which is
+        # reused inside a current document, but no type was defined for the current run.
         # Yeah, this really has happened...
-        return [nodes.Text('', '')]
+        return [nodes.Text("", "")]
+
+    need_type_info = NeedType(
+        directive=need_type,
+        name=type_info["title"],
+        prefix=type_info["prefix"],
+        color=type_info["color"],
+        style=type_info["style"],
+    )
 
     # Get the id or generate a random string/hash string, which is hopefully unique
     # TODO: Check, if id was already given. If True, recalculate id
-    # id = self.options.get("id", ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for
-    # _ in range(5)))
-    if id is None and env.app.config.needs_id_required:
-        raise NeedsNoIdException("An id is missing for this need and must be set, because 'needs_id_required' "
-                                 "is set to True in conf.py. Need '{}' in {} ({})".format(title, docname, lineno))
+    # id = self.options.get(
+    #   "id",
+    #   ''.join(
+    #       random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(5)
+    #   )
+    # )
+    if id is None and config.needs_id_required:
+        raise NeedsNoIdException(
+            "An id is missing for this need and must be set, because 'needs_id_required' "
+            "is set to True in conf.py. Need '{}' in {} ({})".format(
+                title, docname, lineno
+            )
+        )
 
-    if id is None:
-        need_id = make_hashed_id(app, need_type, title, content)
-    else:
-        need_id = id
+    need_id = id or make_hashed_id(need_type_info.prefix, title or content)
 
-    if env.app.config.needs_id_regex and not re.match(env.app.config.needs_id_regex, need_id):
-        raise NeedsInvalidException("Given ID '{id}' does not match configured regex '{regex}'".format(
-            id=need_id, regex=env.app.config.needs_id_regex))
+    if config.needs_id_regex and not re.match(config.needs_id_regex, need_id):
+        raise NeedsInvalidException(
+            "Given ID '{id}' does not match configured regex '{regex}'".format(
+                id=need_id, regex=config.needs_id_regex
+            )
+        )
 
     # Calculate target id, to be able to set a link back
     target_node = nodes.target('', '', ids=[need_id],  refid=need_id)
 
     # Handle status
     # Check if status is in needs_statuses. If not raise an error.
-    if env.app.config.needs_statuses:
-        if status not in [stat["name"] for stat in env.app.config.needs_statuses]:
-            raise NeedsStatusNotAllowed("Status {0} of need id {1} is not allowed "
-                                        "by config value 'needs_statuses'.".format(status, need_id))
+    if config.needs_statuses:
+        if status not in [stat["name"] for stat in config.needs_statuses]:
+            raise NeedsStatusNotAllowed(
+                "Status {0} of need id {1} is not allowed "
+                "by config value 'needs_statuses'.".format(status, need_id)
+            )
 
-    if tags is None:
-        tags = []
-    if len(tags) > 0:
-        tags = [tag.strip() for tag in re.split(";|,", tags)]
-        new_tags = []  # Shall contain only valid tags
-        for i in range(len(tags)):
-            if len(tags[i]) == 0 or tags[i].isspace():
-                logger.warning('Scruffy tag definition found in need {}. '
-                               'Defined tag contains spaces only.'.format(need_id))
-            else:
-                new_tags.append(tags[i])
+    allowed_tags: Optional[List[str]] = None
+    if config.needs_tags:
+        allowed_tags = [tag["name"] for tag in config.needs_tags]
 
-        tags = new_tags
-        # Check if tag is in needs_tags. If not raise an error.
-        if env.app.config.needs_tags:
-            for tag in tags:
-                if tag not in [tag["name"] for tag in env.app.config.needs_tags]:
-                    raise NeedsTagNotAllowed("Tag {0} of need id {1} is not allowed "
-                                             "by config value 'needs_tags'.".format(tag, need_id))
-        # This may have cut also dynamic function strings, as they can contain , as well.
-        # So let put them together again
-        # ToDo: There may be a smart regex for the splitting. This would avoid this mess of code...
-    tags = _fix_list_dyn_func(tags)
+    tag_list = split_tags(tags, need_id, allowed_tags)
 
-    #############################################################################################
+    ####################################################################################
     # Add need to global need list
-    #############################################################################################
+    ####################################################################################
     # be sure, global var is available. If not, create it
-    if not hasattr(env, 'needs_all_needs'):
+    if not hasattr(env, "needs_all_needs"):
         env.needs_all_needs = {}
 
     if need_id in env.needs_all_needs.keys():
         if id:
-            raise NeedsDuplicatedId("A need with ID {} already exists! "
-                                    "This is not allowed. Document {}[{}] Title: {}.".format(need_id, docname,
-                                                                                             lineno, title))
+            raise NeedsDuplicatedId(
+                "A need with ID {} already exists! "
+                "This is not allowed. Document {}[{}] Title: {}.".format(
+                    need_id, docname, lineno, title
+                )
+            )
         else:  # this is a generated ID
             raise NeedsDuplicatedId(
                 "Needs could not generate a unique ID for a need with "
@@ -184,87 +242,89 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
                 "Either supply IDs for the requirements or ensure the "
                 "titles are different.  NOTE: If title is being generated "
                 "from the content, then ensure the first sentence of the "
-                "requirements are different.".format(' '.join(title)))
+                "requirements are different.".format(" ".join(title))
+            )
 
     # Trim title if it is too long
     max_length = env.app.config.needs_max_title_length
-    if max_length == -1 or len(title) <= max_length:
-        trimmed_title = title
-    elif max_length <= 3:
-        trimmed_title = title[:max_length]
-    else:
-        trimmed_title = title[:max_length - 3] + '...'
+    trimmed_title = utils.trim_title(title, max_length)
 
     # Add the need and all needed information
     needs_info = {
-        'docname': docname,
-        'lineno': lineno,
-        'target_node': target_node,
-        'content_node': None,  # gets set after rst parsing
-        'type': need_type,
-        'type_name': type_name,
-        'type_prefix': type_prefix,
-        'type_color': type_color,
-        'type_style': type_style,
-        'status': status,
-        'tags': tags,
-        'id': need_id,
-        'title': trimmed_title,
-        'full_title': title,
-        'content': content,
-        'collapse': collapse,
-        'style': style,
-        'layout': layout,
-        'template': template,
-        'pre_template': pre_template,
-        'post_template': post_template,
-        'hide': hide,
-        'parts': {},
-
-        'is_part': False,
-        'is_need': True
+        "docname": docname,
+        "lineno": lineno,
+        "target_node": target_node,
+        "content_node": None,  # gets set after rst parsing
+        "type": need_type_info.directive,
+        "type_name": need_type_info.name,
+        "type_prefix": need_type_info.prefix,
+        "type_color": need_type_info.color,
+        "type_style": need_type_info.style,
+        "status": status,
+        "tags": tag_list,
+        "id": need_id,
+        "title": trimmed_title,
+        "full_title": title,
+        "content": content,
+        "collapse": collapse,
+        "style": style,
+        "layout": layout,
+        "template": template,
+        "pre_template": pre_template,
+        "post_template": post_template,
+        "hide": hide,
+        "parts": {},
+        "is_part": False,
+        "is_need": True,
     }
-    needs_extra_options = env.config.needs_extra_options.keys()
+    needs_extra_options = config.needs_extra_options.keys()
     _merge_extra_options(needs_info, kwargs, needs_extra_options)
 
-    needs_global_options = env.config.needs_global_options
+    needs_global_options = config.needs_global_options
     _merge_global_options(needs_info, needs_global_options)
 
-    link_names = [x['option'] for x in env.config.needs_extra_links]
+    link_names = [x["option"] for x in config.needs_extra_links]
     for keyword in kwargs:
         if keyword not in needs_extra_options and keyword not in link_names:
-            raise NeedsInvalidOption('Unknown Option {}. '
-                                     'Use needs_extra_options or needs_extra_links in conf.py'
-                                     'to define this option.'.format(keyword))
+            raise NeedsInvalidOption(
+                "Unknown Option {}. "
+                "Use needs_extra_options or needs_extra_links in conf.py"
+                "to define this option.".format(keyword)
+            )
 
     # Merge links
     copy_links = []
 
-    for link_type in env.config.needs_extra_links:
+    for link_type in config.needs_extra_links:
         # Check, if specific link-type got some arguments during method call
-        if link_type['option'] not in list(kwargs.keys()) and link_type['option'] not in needs_global_options.keys():
+        if (
+            link_type["option"] not in list(kwargs.keys())
+            and link_type["option"] not in needs_global_options.keys()
+        ):
             # if not we set no links, but entry in needS_info must be there
             links = []
-        elif link_type['option'] in needs_global_options.keys() and \
-                (link_type['option'] not in list(kwargs.keys()) or len(str(kwargs[link_type['option']])) == 0):
+        elif link_type["option"] in needs_global_options.keys() and (
+            link_type["option"] not in list(kwargs.keys())
+            or len(str(kwargs[link_type["option"]])) == 0
+        ):
             # If it is in global option, value got already set during prior handling of them
-            links_string = needs_info[link_type['option']]
-            links = _read_in_links(links_string)
+            links_string = needs_info[link_type["option"]]
+            links = utils.read_in_links(links_string)
         else:
             # if it is set in kwargs, take this value and maybe override set value from global_options
-            links_string = kwargs[link_type['option']]
-            links = _read_in_links(links_string)
+            links_string = kwargs[link_type["option"]]
+            links = utils.read_in_links(links_string)
 
         needs_info[link_type["option"]] = links
-        needs_info['{}_back'.format(link_type["option"])] = set()
+        needs_info["{}_back".format(link_type["option"])] = set()
 
-        if 'copy' not in link_type.keys():
-            link_type['copy'] = False
+        if "copy" not in link_type.keys():
+            link_type["copy"] = False
 
-        if link_type['copy'] and link_type['option'] != 'links':
+        if link_type["copy"] and link_type["option"] != "links":
             copy_links += links  # Save extra links for main-links
 
-    needs_info['links'] += copy_links  # Set copied links to main-links
+    needs_info["links"] += copy_links  # Set copied links to main-links
 
     env.needs_all_needs[need_id] = needs_info
 
@@ -272,37 +332,39 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
     ##############################
 
     # template
-    if needs_info['template']:
-        new_content = _prepare_template(app, needs_info, 'template')
+    if needs_info["template"]:
+        new_content = _prepare_template(app, needs_info, "template")
         # Overwrite current content
         content = new_content
-        needs_info['content'] = new_content
+        needs_info["content"] = new_content
     else:
         new_content = None
 
     # pre_template
-    if needs_info['pre_template']:
-        pre_content = _prepare_template(app, needs_info, 'pre_template')
-        needs_info['pre_content'] = pre_content
+    if needs_info["pre_template"]:
+        pre_content = _prepare_template(app, needs_info, "pre_template")
+        needs_info["pre_content"] = pre_content
     else:
         pre_content = None
 
     # post_template
-    if needs_info['post_template']:
-        post_content = _prepare_template(app, needs_info, 'post_template')
-        needs_info['post_content'] = post_content
+    if needs_info["post_template"]:
+        post_content = _prepare_template(app, needs_info, "post_template")
+        needs_info["post_content"] = post_content
     else:
         post_content = None
 
-    if needs_info['hide']:
+    if needs_info["hide"]:
         return [target_node]
 
     # Adding of basic Need node.
     ############################
-    # Title and meta data information gets added alter during event handling via process_need_nodes()
-    # We just add a basic need node and render the rst-based content, because this can not be done later.
-    # style_classes = ['need', type_name, 'need-{}'.format(type_name.lower())]  # Used < 0.4.4
-    style_classes = ['need', 'need-{}'.format(need_type.lower())]
+    # Title and meta data information gets added alter during event handling via
+    # process_need_nodes(). We just add a basic need node and render the rst-based
+    # content, because this can not be done later.
+    # style_classes = ['need', type_name, 'need-{}'.format(type_name.lower())]
+    # # Used < 0.4.4
+    style_classes = ["need", "need-{}".format(need_type_info.directive.lower())]
     if style:
         style_classes.append(style)
 
@@ -317,7 +379,7 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
 
     node_need += node_need_content.children
 
-    needs_info['content_node'] = node_need
+    needs_info["content_node"] = node_need
 
     return_nodes = [target_node] + [node_need]
     if pre_content:
@@ -335,127 +397,61 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
     return return_nodes
 
 
-def _prepare_template(app, needs_info, template_key):
+def make_hashed_id(
+    prefix: str,
+    content: str,
+    id_length: Optional[int] = None,
+) -> str:
+    """
+    Creates an ID based on title or need.
+
+    Also cares about the correct prefix, which is specified for each need type.
+
+    :param prefix: the prefix of the id of every need of this type
+    :param content: the content to be hashed
+    :param id_length: maximum length of the generated ID
+    :return: ID as string
+    """
+
+    return "{}{}".format(
+        prefix,
+        hashlib.sha1(content.encode("UTF-8")).hexdigest().upper()[:id_length],
+    )
+
+
+def _prepare_template(app: Sphinx, needs_info, template_key) -> str:
     template_folder = app.config.needs_template_folder
     if not os.path.isabs(template_folder):
         template_folder = os.path.join(app.confdir, template_folder)
 
     if not os.path.isdir(template_folder):
-        raise NeedsTemplateException('Template folder does not exist: {}'.format(template_folder))
+        raise NeedsTemplateException(
+            "Template folder does not exist: {}".format(template_folder)
+        )
 
-    template_file_name = needs_info[template_key] + '.need'
+    template_file_name = needs_info[template_key] + ".need"
     template_path = os.path.join(template_folder, template_file_name)
     if not os.path.isfile(template_path):
-        raise NeedsTemplateException('Template does not exist: {}'.format(template_path))
+        raise NeedsTemplateException(
+            "Template does not exist: {}".format(template_path)
+        )
 
-    with open(template_path, 'r') as template_file:
-        template_content = ''.join(template_file.readlines())
+    with open(template_path, "r") as template_file:
+        template_content = "".join(template_file.readlines())
     template_obj = Template(template_content)
     new_content = template_obj.render(**needs_info)
 
     return new_content
 
 
-def _render_template(content, docname, lineno, state):
+def _render_template(content: str, docname: str, lineno: int, state) -> nodes.Element:
     rst = ViewList()
-    for line in content.split('\n'):
+    for line in content.split("\n"):
         rst.append(line, docname, lineno)
     node_need_content = nodes.Element()
     node_need_content.document = state.document
     nested_parse_with_titles(state, rst, node_need_content)
     return node_need_content
-
-
-def _read_in_links(links_string):
-    # Get links
-    links = []
-    if links_string:
-        for link in re.split(";|,", links_string):
-            if link.isspace():
-                logger.warning('Grubby link definition found in need {}. '
-                               'Defined link contains spaces only.'.format(id))
-            else:
-                links.append(link.strip())
-
-        # This may have cut also dynamic function strings, as they can contain , as well.
-        # So let put them together again
-        # ToDo: There may be a smart regex for the splitting. This would avoid this mess of code...
-    return _fix_list_dyn_func(links)
-
-
-def make_hashed_id(app, need_type, full_title, content, id_length=None):
-    """
-    Creates an ID based on title or need.
-
-    Also cares about the correct prefix, which is specified for each need type.
-
-    :param app: Sphinx application object
-    :param need_type: name of the need directive, e.g. req
-    :param full_title: full title of the need
-    :param content: content of the need
-    :param id_length: maximum length of the generated ID
-    :return: ID as string
-    """
-    types = app.config.needs_types
-    if id_length is None:
-        id_length = app.config.needs_id_length
-    type_prefix = None
-    for ntype in types:
-        if ntype["directive"] == need_type:
-            type_prefix = ntype["prefix"]
-            break
-    if type_prefix is None:
-        raise NeedsInvalidException('Given need_type {} is unknown. File {}'.format(need_type, app.env.docname))
-
-    hashable_content = full_title or '\n'.join(content)
-    return "%s%s" % (type_prefix,
-                     hashlib.sha1(hashable_content.encode("UTF-8"))
-                     .hexdigest()
-                     .upper()[:id_length])
-
-
-def _fix_list_dyn_func(list):
-    """
-    This searches a list for dynamic function fragments, which may have been cut by generic searches for ",|;".
-
-    Example:
-    `link_a, [[copy('links', need_id)]]` this will be splitted in list of 3 parts:
-
-    #. link_a
-    #. [[copy('links'
-    #. need_id)]]
-
-    This function fixes the above list to the following:
-
-    #. link_a
-    #. [[copy('links', need_id)]]
-
-    :param list: list which may contain splitted function calls
-    :return: list of fixed elements
-    """
-    open_func_string = False
-    new_list = []
-    for element in list:
-        # If dyn_func got not cut, just add it
-        if '[[' in element and ']]' in element:
-            new_list.append(element)
-        # Other check if this is the starting element of dyn function
-        elif '[[' in element:
-            open_func_string = True
-            new_link = [element]
-        # Check if this is the ending element if dyn function
-        elif ']]' in element:
-            new_link.append(element)
-            open_func_string = False
-            element = ",".join(new_link)
-            new_list.append(element)
-        # Check it is a "middle" part of the dyn function
-        elif open_func_string:
-            new_link.append(element)
-        # Looks like it isn't a cut dyn_func, just add.
-        else:
-            new_list.append(element)
-    return new_list
 
 
 def _merge_extra_options(needs_info, needs_kwargs, needs_extra_options):
@@ -480,7 +476,7 @@ def _merge_global_options(needs_info, global_options):
     for key, value in global_options.items():
 
         # If key already exists in needs_info, this global_option got overwritten manually in current need
-        if key in needs_info.keys() and needs_info[key]:
+        if needs_info.get(key, None):
             continue
 
         if isinstance(value, tuple):
@@ -492,16 +488,21 @@ def _merge_global_options(needs_info, global_options):
             continue
 
         for single_value in values:
-            if len(single_value) < 2 or len(single_value) > 3:
-                raise NeedsInvalidException('global option tuple has wrong amount of parameters: {}'.format(key))
+            length = len(single_value)
+            if not (length == 2 or length == 3):
+                raise NeedsInvalidException(
+                    "global option tuple has wrong amount of parameters: {}".format(key)
+                )
             if filter_single_need(needs_info, single_value[1]):
                 # Set value, if filter has matched
                 needs_info[key] = single_value[0]
-            elif len(single_value) == 3 and (key not in needs_info.keys() or len(str(needs_info[key])) > 0):
+            elif len(single_value) == 3 and (
+                key not in needs_info.keys() or len(str(needs_info[key])) > 0
+            ):
                 # Otherwise set default, but only if no value was set before or value is "" and a default is defined
                 needs_info[key] = single_value[2]
             else:
                 # If not value was set until now, we have to set an empty value, so that we are sure that each need
                 # has at least the key.
                 if key not in needs_info.keys():
-                    needs_info[key] = ''
+                    needs_info[key] = ""

--- a/sphinxcontrib/needs/api/need.py
+++ b/sphinxcontrib/needs/api/need.py
@@ -323,8 +323,6 @@ def add_need(
     # Title and meta data information gets added alter during event handling via
     # process_need_nodes(). We just add a basic need node and render the rst-based
     # content, because this can not be done later.
-    # style_classes = ['need', type_name, 'need-{}'.format(type_name.lower())]
-    # # Used < 0.4.4
     style_classes = ["need", "need-{}".format(need_type_info.directive.lower())]
     if style:
         style_classes.append(style)

--- a/sphinxcontrib/needs/api/need.py
+++ b/sphinxcontrib/needs/api/need.py
@@ -207,12 +207,12 @@ def add_need(
 
     # Handle status
     # Check if status is in needs_statuses. If not raise an error.
-    if config.needs_statuses:
-        if status not in [stat["name"] for stat in config.needs_statuses]:
-            raise NeedsStatusNotAllowed(
-                "Status {0} of need id {1} is not allowed "
-                "by config value 'needs_statuses'.".format(status, need_id)
-            )
+    allowed_status_names = (s["name"] for s in config.needs_statuses)
+    if config.needs_statuses and status not in allowed_status_names:
+        raise NeedsStatusNotAllowed(
+            "Status {0} of need id {1} is not allowed "
+            "by config value 'needs_statuses'.".format(status, need_id)
+        )
 
     allowed_tags: Optional[List[str]] = None
     if config.needs_tags:
@@ -307,11 +307,13 @@ def add_need(
             link_type["option"] not in list(kwargs.keys())
             or len(str(kwargs[link_type["option"]])) == 0
         ):
-            # If it is in global option, value got already set during prior handling of them
+            # If it is in global option, value got already set during prior handling of
+            # them
             links_string = needs_info[link_type["option"]]
             links = utils.read_in_links(links_string)
         else:
-            # if it is set in kwargs, take this value and maybe override set value from global_options
+            # if it is set in kwargs, take this value and maybe override set value from
+            # global_options
             links_string = kwargs[link_type["option"]]
             links = utils.read_in_links(links_string)
 


### PR DESCRIPTION
- simplify a few methods
- reduce duplication between `directives/need` and `api/need`
- format imports with isort
- format `api/need` using Black
- add type annotations