### PR TITLE
Refactor configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -253,7 +253,6 @@ if os.name == "nt":
 # plantuml_output_format = 'png'
 plantuml_output_format = 'svg_img'
 
-# needs_collapse_details = True
 needs_table_style = "datatables"
 needs_table_columns = "ID;TITLE;STATUS;OUTGOING"
 

--- a/docs/directives/need.rst
+++ b/docs/directives/need.rst
@@ -174,8 +174,6 @@ If set to **True**, details like status, links or tags are collapsed and viewabl
 
 If set to **False**, details are shown directly.
 
-If not set, the config parameter :ref:`needs_collapse_details` decides about the behavior.
-
 Allowed values:
 
  * true; yes; 1

--- a/sphinxcontrib/needs/api/configuration.py
+++ b/sphinxcontrib/needs/api/configuration.py
@@ -8,9 +8,10 @@ from docutils.parsers.rst import directives
 from sphinxcontrib.needs.api.exceptions import NeedsNotLoadedException, NeedsApiConfigException, NeedsApiConfigWarning
 from sphinxcontrib.needs.functions import register_func
 import sphinxcontrib.needs.directives.need
+from sphinx.application import Sphinx
 
 
-def get_need_types(app):
+def get_need_types(app: Sphinx):
     """
     Returns a list of directive-names from all configured need_types.
 
@@ -23,11 +24,11 @@ def get_need_types(app):
     :param app: Sphinx application object
     :return: list of strings
     """
-    needs_types = getattr(app.config, 'needs_types', [])
+    needs_types = app.config.needs_types
     return [x['directive'] for x in needs_types]
 
 
-def add_need_type(app, directive, title, prefix, color='#ffffff', style='node'):
+def add_need_type(app: Sphinx, directive, title, prefix, color='#ffffff', style='node'):
     """
     Adds a new need_type to the configuration.
 
@@ -49,10 +50,8 @@ def add_need_type(app, directive, title, prefix, color='#ffffff', style='node'):
     :param style: Plantuml-style for needflow representation. Default: 'node'
     :return: None
     """
-    if not hasattr(app.config, 'needs_types'):
-        raise NeedsNotLoadedException('needs_types missing in configuration.')
 
-    needs_types = getattr(app.config, 'needs_types', [])
+    needs_types = app.config.needs_types
     type_names = [x['directive'] for x in needs_types]
 
     if directive in type_names:
@@ -84,10 +83,8 @@ def add_extra_option(app, name):
     :param name: Name as string of the extra option
     :return: None
     """
-    if not hasattr(app.config, 'needs_extra_options'):
-        raise NeedsNotLoadedException('needs_extra_options missing in configuration.')
 
-    extra_options = getattr(app.config, 'needs_extra_options', {})
+    extra_options = app.config.needs_extra_options
 
     if name in extra_options.keys():
         raise NeedsApiConfigWarning('Option {} already registered.'.format(name))

--- a/sphinxcontrib/needs/api/need.py
+++ b/sphinxcontrib/needs/api/need.py
@@ -134,10 +134,6 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
     # Calculate target id, to be able to set a link back
     target_node = nodes.target('', '', ids=[need_id])
 
-    # Removed 0.5.0
-    # if collapse is None:
-    #     collapse = getattr(env.app.config, "needs_collapse_details", True)
-
     # Handle status
     # Check if status is in needs_statuses. If not raise an error.
     if env.app.config.needs_statuses:

--- a/sphinxcontrib/needs/api/need.py
+++ b/sphinxcontrib/needs/api/need.py
@@ -187,7 +187,7 @@ def add_need(app, state, docname, lineno, need_type, title, id=None, content="",
                 "requirements are different.".format(' '.join(title)))
 
     # Trim title if it is too long
-    max_length = getattr(env.app.config, 'needs_max_title_length', 30)
+    max_length = env.app.config.needs_max_title_length
     if max_length == -1 or len(title) <= max_length:
         trimmed_title = title
     elif max_length <= 3:

--- a/sphinxcontrib/needs/directives/need.py
+++ b/sphinxcontrib/needs/directives/need.py
@@ -81,15 +81,13 @@ class NeedDirective(Directive):
 
         # ToDo: Keep this in directive!!!
         collapse = self.options.get("collapse", None)
-        if isinstance(collapse, str) and len(collapse) > 0:
+        if isinstance(collapse, str):
             if collapse.upper() in ["TRUE", 1, "YES"]:
                 collapse = True
             elif collapse.upper() in ["FALSE", 0, "NO"]:
                 collapse = False
             else:
                 raise Exception("collapse attribute must be true or false")
-        else:
-            collapse = getattr(env.app.config, "needs_collapse_details", None)
 
         hide = True if "hide" in self.options.keys() else False
 
@@ -296,9 +294,7 @@ def process_need_nodes(app, doctree, fromdocname):
         for index, attribute in enumerate(node_need.attributes['classes']):
             node_need.attributes['classes'][index] = check_and_get_content(attribute, need_data, env)
 
-        layout = need_data['layout']
-        if layout is None or len(layout) == 0:
-            layout = getattr(app.config, 'needs_default_layout', 'clean')
+        layout = need_data['layout'] or app.config.needs_default_layout
 
         build_need(layout, node_need, app)
 

--- a/sphinxcontrib/needs/layout.py
+++ b/sphinxcontrib/needs/layout.py
@@ -14,11 +14,11 @@ from docutils.parsers.rst.states import Inliner, Struct
 from docutils.utils import new_document
 
 from urllib.parse import urlparse
-
+from sphinx.application import Sphinx
 from sphinxcontrib.needs.utils import INTERNALS
 
 
-def create_need(need_id, app, layout=None, style=None, docname=None):
+def create_need(need_id, app: Sphinx, layout=None, style=None, docname=None):
     """
     Creates a new need-node for a given layout.
 
@@ -56,17 +56,8 @@ def create_need(need_id, app, layout=None, style=None, docname=None):
 
     node_inner.attributes['ids'].append(need_id)
 
-    if layout is None:
-        if need_data['layout'] is None or len(need_data['layout']) == 0:
-            layout = getattr(app.config, 'needs_default_layout', 'clean')
-        else:
-            layout = need_data['layout']
-
-    if style is None:
-        if need_data['style'] is None or len(need_data['style']) == 0:
-            style = getattr(app.config, 'needs_default_style', 'None')
-        else:
-            style = need_data['style']
+    layout = layout or need_data['layout'] or app.config.needs_default_layout
+    style = style or need_data['style'] or app.config.needs_default_style
 
     build_need(layout, node_inner, app, style, docname)
 
@@ -145,7 +136,7 @@ class LayoutHandler:
         self.need = need
 
         self.layout_name = layout
-        available_layouts = getattr(app.config, 'needs_layouts', {})
+        available_layouts = app.config.needs_layouts
         if self.layout_name not in available_layouts.keys():
             raise SphinxNeedLayoutException(
                 'Given layout "{}" is unknown for need {}. Registered layouts are: {}'.format(

--- a/sphinxcontrib/needs/needs.py
+++ b/sphinxcontrib/needs/needs.py
@@ -248,25 +248,23 @@ def setup(app):
             'parallel_write_safe': True}
 
 
-def load_config(app, *args):
+def load_config(app: Sphinx, *args):
     """
     Register extra options and directive based on config from con.py
     """
     types = app.config.needs_types
-    extra_options = getattr(app.config, "needs_extra_options", app.config.needs_extra_options)
+    extra_options = app.config.needs_extra_options
 
     # Get extra links and create a dictionary of needed options.
-    extra_links_raw = getattr(app.config, "needs_extra_links", app.config.needs_extra_links)
+    extra_links_raw = app.config.needs_extra_links
     extra_links = {}
     for extra_link in extra_links_raw:
         extra_links[extra_link['option']] = directives.unchanged
 
-    title_optional = getattr(app.config, "needs_title_optional", app.config.needs_title_optional)
-    title_from_content = getattr(app.config, "needs_title_from_content", app.config.needs_title_from_content)
-    # app.needs_functions = getattr(app.config, "needs_functions", [])
+    title_optional = app.config.needs_title_optional
+    title_from_content = app.config.needs_title_from_content
     global NEEDS_FUNCTIONS_CONF
-    NEEDS_FUNCTIONS_CONF = getattr(app.config, "needs_functions", [])
-    # app.needs_functions = []
+    NEEDS_FUNCTIONS_CONF = app.config.needs_functions
 
     # Update NeedDirective to use customized options
     NeedDirective.option_spec.update(extra_options)
@@ -322,10 +320,13 @@ def prepare_env(app, env, docname):
             app.needs_services.register(name, service['class'], **service['class_init'])
 
     needs_functions = NEEDS_FUNCTIONS_CONF
+<<<<<<< HEAD
     if needs_functions is None:
         needs_functions = []
     if not isinstance(needs_functions, list):
         raise SphinxError('Config parameter needs_functions must be a list!')
+=======
+>>>>>>> bb13600... remove some redundant checks
 
     # Register built-in functions
     for need_common_func in needs_common_functions:
@@ -341,7 +342,8 @@ def prepare_env(app, env, docname):
         if option not in app.config.needs_extra_options.keys():
             app.config.needs_extra_options[option] = directives.unchanged
 
-    # The default link name. Must exist in all configurations. Therefore we set it here for the user.
+    # The default link name. Must exist in all configurations. Therefore we set it here
+    # for the user.
     common_links = []
     link_types = app.config.needs_extra_links
     basic_link_type_found = False
@@ -368,8 +370,8 @@ def prepare_env(app, env, docname):
     if not hasattr(env, 'needs_workflow'):
         # Used to store workflow status information for already executed tasks.
         # Some tasks like backlink_creation need be be performed only once.
-        # But most sphinx-events get called several times (for each single document file), which would also
-        # execute our code several times...
+        # But most sphinx-events get called several times (for each single document
+        # file), which would also execute our code several times...
         env.needs_workflow = {
             'backlink_creation_links': False,
             'dynamic_values_resolved': False

--- a/sphinxcontrib/needs/needs.py
+++ b/sphinxcontrib/needs/needs.py
@@ -60,39 +60,42 @@ def setup(app):
                           # Kept for backwards compatibility
                           dict(directive="need", title="Need", prefix="N_", color="#9856a5", style="node")],
                          'html')
-    app.add_config_value('needs_include_needs', True, 'html')
-    app.add_config_value('needs_need_name', "Need", 'html')
-    app.add_config_value('needs_spec_name', "Specification", 'html')
-    app.add_config_value('needs_id_prefix_needs', "", 'html')
-    app.add_config_value('needs_id_prefix_specs', "", 'html')
-    app.add_config_value('needs_id_length', 5, 'html')
-    app.add_config_value('needs_specs_show_needlist', False, 'html')
-    app.add_config_value('needs_id_required', False, 'html')
-    app.add_config_value('needs_id_regex', "^[A-Z0-9_]{{{id_length},}}".format(
-        id_length=app.config.needs_id_length), 'html')
-    app.add_config_value('needs_show_link_type', False, 'html')
-    app.add_config_value('needs_show_link_title', False, 'html')
-    app.add_config_value('needs_file', "needs.json", 'html')
-    app.add_config_value('needs_table_columns', "ID;TITLE;STATUS;TYPE;OUTGOING;TAGS", 'html')
-    app.add_config_value('needs_table_style', "DATATABLES", 'html')
+    app.add_config_value("needs_include_needs", True, "html", types=[bool])
+    app.add_config_value("needs_need_name", "Need", "html", types=[str])
+    app.add_config_value("needs_spec_name", "Specification", "html", types=[str])
+    app.add_config_value("needs_id_prefix_needs", "", "html", types=[str])
+    app.add_config_value("needs_id_prefix_specs", "", "html", types=[str])
+    app.add_config_value("needs_id_length", 5, "html", types=[int])
+    app.add_config_value("needs_specs_show_needlist", False, "html", types=[bool])
+    app.add_config_value("needs_id_required", False, "html", types=[bool])
+    app.add_config_value(
+        "needs_id_regex",
+        "^[A-Z0-9_]{{{id_length},}}".format(id_length=app.config.needs_id_length),
+        "html",
+    )
+    app.add_config_value("needs_show_link_type", False, "html", types=[bool])
+    app.add_config_value("needs_show_link_title", False, "html", types=[bool])
+    app.add_config_value("needs_file", "needs.json", "html")
+    app.add_config_value(
+        "needs_table_columns", "ID;TITLE;STATUS;TYPE;OUTGOING;TAGS", "html"
+    )
+    app.add_config_value("needs_table_style", "DATATABLES", "html")
 
-    app.add_config_value('needs_role_need_template', u"{title} ({id})", 'html')
-    app.add_config_value('needs_role_need_max_title_length', 30, 'html')
+    app.add_config_value("needs_role_need_template", u"{title} ({id})", "html")
+    app.add_config_value("needs_role_need_max_title_length", 30, "html", types=[int])
 
-    app.add_config_value('needs_extra_options', {}, 'html')
-    app.add_config_value('needs_title_optional', False, 'html')
-    app.add_config_value('needs_max_title_length', -1, 'html')
-    app.add_config_value('needs_title_from_content', False, 'html')
+    app.add_config_value("needs_extra_options", {}, "html")
+    app.add_config_value("needs_title_optional", False, "html", types=[bool])
+    app.add_config_value("needs_max_title_length", -1, "html", types=[int])
+    app.add_config_value("needs_title_from_content", False, "html", types=[bool])
 
-    app.add_config_value('needs_diagram_template',
-                         DEFAULT_DIAGRAM_TEMPLATE,
-                         'html')
+    app.add_config_value("needs_diagram_template", DEFAULT_DIAGRAM_TEMPLATE, "html")
 
-    app.add_config_value('needs_functions', [], 'html')
-    app.add_config_value('needs_global_options', {}, 'html')
+    app.add_config_value("needs_functions", [], "html", types=[list])
+    app.add_config_value("needs_global_options", {}, "html", types=[dict])
 
-    app.add_config_value('needs_duration_option', 'duration', 'html')
-    app.add_config_value('needs_completion_option', 'completion', 'html')
+    app.add_config_value("needs_duration_option", "duration", "html")
+    app.add_config_value("needs_completion_option", "completion", "html")
 
     # If given, only the defined status are allowed.
     # Values needed for each status:
@@ -106,7 +109,7 @@ def setup(app):
     # * name
     # * description
     # Example: [{"name": "new", "description": "new needs"}, {...}, {...}]
-    app.add_config_value('needs_tags', False, 'html')
+    app.add_config_value("needs_tags", False, "html", types=[bool])
 
     # Path of css file, which shall be used for need style
     app.add_config_value('needs_css', "modern.css", 'html')
@@ -135,10 +138,10 @@ def setup(app):
 
     app.add_config_value('needs_template_folder', 'needs_templates/', 'html')
 
-    app.add_config_value('needs_services', {}, 'html')
-    app.add_config_value('needs_service_all_data', False, 'html')
+    app.add_config_value("needs_services", {}, "html")
+    app.add_config_value("needs_service_all_data", False, "html", types=[bool])
 
-    app.add_config_value('needs_debug_no_external_calls', False, 'html')
+    app.add_config_value("needs_debug_no_external_calls", False, "html", types=[bool])
 
     # Define nodes
     app.add_node(Need, html=(html_visit, html_depart), latex=(latex_visit, latex_depart))

--- a/sphinxcontrib/needs/needs.py
+++ b/sphinxcontrib/needs/needs.py
@@ -3,6 +3,12 @@
 from sphinx.errors import SphinxError
 from docutils import nodes
 from docutils.parsers.rst import directives
+<<<<<<< HEAD
+=======
+from sphinx.application import Sphinx
+from sphinx.config import Config
+from sphinx.errors import SphinxError
+>>>>>>> 44bd52d... tidy up
 from sphinx.roles import XRefRole
 from sphinxcontrib.needs.directives.need import Need, NeedDirective, \
     process_need_nodes, purge_needs, add_sections, html_visit, html_depart, latex_visit, latex_depart
@@ -37,14 +43,14 @@ from sphinxcontrib.needs.logging import getLogger
 
 VERSION = '0.6.0'
 
-NEEDS_FUNCTIONS_CONF = []
-
 
 class TagsDummy:
     """
     Dummy class for faking tags.has() feature during own import of conf.py
     """
-    def has(self, *args):
+
+    @staticmethod
+    def has(*_args):
         return True
 
 
@@ -251,7 +257,7 @@ def setup(app):
             'parallel_write_safe': True}
 
 
-def load_config(app: Sphinx, *args):
+def load_config(app: Sphinx, *_args):
     """
     Register extra options and directive based on config from con.py
     """
@@ -266,8 +272,6 @@ def load_config(app: Sphinx, *args):
 
     title_optional = app.config.needs_title_optional
     title_from_content = app.config.needs_title_from_content
-    global NEEDS_FUNCTIONS_CONF
-    NEEDS_FUNCTIONS_CONF = app.config.needs_functions
 
     # Update NeedDirective to use customized options
     NeedDirective.option_spec.update(extra_options)
@@ -281,19 +285,19 @@ def load_config(app: Sphinx, *args):
         NeedDirective.required_arguments = 0
         NeedDirective.optional_arguments = 1
 
-    for type in types:
+    for t in types:
         # Register requested types of needs
-        app.add_directive(type["directive"], NeedDirective)
+        app.add_directive(t["directive"], NeedDirective)
 
 
-def visitor_dummy(*args, **kwargs):
+def visitor_dummy(*_args, **_kwargs):
     """
     Dummy class for visitor methods, which does nothing.
     """
     pass
 
 
-def prepare_env(app, env, docname):
+def prepare_env(app, env, _docname):
     """
     Prepares the sphinx environment to store sphinx-needs internal data.
     """
@@ -322,6 +326,7 @@ def prepare_env(app, env, docname):
             # We found a not yet registered service
             app.needs_services.register(name, service['class'], **service['class_init'])
 
+<<<<<<< HEAD
     needs_functions = NEEDS_FUNCTIONS_CONF
 <<<<<<< HEAD
     if needs_functions is None:
@@ -330,6 +335,9 @@ def prepare_env(app, env, docname):
         raise SphinxError('Config parameter needs_functions must be a list!')
 =======
 >>>>>>> bb13600... remove some redundant checks
+=======
+    needs_functions = app.config.needs_functions
+>>>>>>> 44bd52d... tidy up
 
     # Register built-in functions
     for need_common_func in needs_common_functions:
@@ -383,7 +391,7 @@ def prepare_env(app, env, docname):
             env.needs_workflow['backlink_creation_{}'.format(link_type['option'])] = False
 
 
-def check_configuration(app, config):
+def check_configuration(_app: Sphinx, config: Config):
     """
     Checks the configuration for invalid options.
 

--- a/sphinxcontrib/needs/needs.py
+++ b/sphinxcontrib/needs/needs.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from sphinx.errors import SphinxError
 from docutils import nodes
 from docutils.parsers.rst import directives
-<<<<<<< HEAD
-=======
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.errors import SphinxError
->>>>>>> 44bd52d... tidy up
 from sphinx.roles import XRefRole
 from sphinxcontrib.needs.directives.need import Need, NeedDirective, \
     process_need_nodes, purge_needs, add_sections, html_visit, html_depart, latex_visit, latex_depart
@@ -326,18 +322,7 @@ def prepare_env(app, env, _docname):
             # We found a not yet registered service
             app.needs_services.register(name, service['class'], **service['class_init'])
 
-<<<<<<< HEAD
-    needs_functions = NEEDS_FUNCTIONS_CONF
-<<<<<<< HEAD
-    if needs_functions is None:
-        needs_functions = []
-    if not isinstance(needs_functions, list):
-        raise SphinxError('Config parameter needs_functions must be a list!')
-=======
->>>>>>> bb13600... remove some redundant checks
-=======
     needs_functions = app.config.needs_functions
->>>>>>> 44bd52d... tidy up
 
     # Register built-in functions
     for need_common_func in needs_common_functions:

--- a/sphinxcontrib/needs/warnings.py
+++ b/sphinxcontrib/needs/warnings.py
@@ -40,7 +40,7 @@ def process_warnings(app, exception):
 
     needs = env.needs_all_needs
 
-    warnings = getattr(app.config, 'needs_warnings', {})
+    warnings = app.config.needs_warnings
 
     with logging.pending_logging():
         logger.info('\nChecking sphinx-needs warnings')

--- a/tests/doc_test/doc_export_id/conf.py
+++ b/tests/doc_test/doc_export_id/conf.py
@@ -69,8 +69,6 @@ needs_extra_links = [
 
 needs_flow_link_types = ['links', 'tests']
 
-needs_collapse_details = False
-
 cwd = os.path.dirname(__file__)
 plantuml = 'java -jar %s' % os.path.join(cwd, "../utils/plantuml_beta.jar")
 

--- a/tests/doc_test/doc_extra_links/conf.py
+++ b/tests/doc_test/doc_extra_links/conf.py
@@ -69,8 +69,6 @@ needs_extra_links = [
 
 needs_flow_link_types = ['links', 'tests']
 
-needs_collapse_details = False
-
 cwd = os.path.dirname(__file__)
 plantuml = 'java -jar %s' % os.path.join(cwd, "../utils/plantuml_beta.jar")
 


### PR DESCRIPTION
i'm refactored the configuration in the setup function, and a few places where that configuration is consumed.

There's a lot of checking attributes and types throughout, which is unnecessary since the sphinx application API ensures config values are present, have defaults, and are the correct type. there's no need to do this again.

i've also removed a `global` parameter ("NEEDS_FUNCTIONS_CONF"). It didn't seem to be doing anything, and global variables are almost never what you want