### PR TITLE
tidy 'urlparse' imports

### DIFF
--- a/sphinxcontrib/needs/directives/needextract.py
+++ b/sphinxcontrib/needs/directives/needextract.py
@@ -3,16 +3,12 @@
 
 """
 
-import urllib
-
 from docutils import nodes
 from docutils.parsers.rst import directives
 
 from sphinxcontrib.needs.layout import create_need
 from sphinxcontrib.needs.filter_common import FilterBase, process_filters
 from sphinxcontrib.needs.directives.utils import no_needs_found_paragraph, used_filter_paragraph
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needextract(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needfilter.py
+++ b/sphinxcontrib/needs/directives/needfilter.py
@@ -1,5 +1,5 @@
 import os
-import urllib
+from urllib.parse import urlparse
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -13,8 +13,6 @@ except ImportError:
 from sphinxcontrib.needs.diagrams_common import create_legend
 from sphinxcontrib.needs.filter_common import FilterBase, process_filters
 from sphinxcontrib.needs.utils import row_col_maker
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needfilter(nodes.General, nodes.Element):
@@ -191,7 +189,7 @@ def process_needfilters(app, doctree, fromdocname):
                 # and not to current documentation. Therefore we need to add ../ to get out of the image folder.
                 try:
                     link = "../" + app.builder.get_target_uri(need_info['docname']) \
-                           + "?highlight={0}".format(urlParse(need_info['title'])) \
+                           + "?highlight={0}".format(urlparse(need_info['title'])) \
                            + "#" \
                            + need_info['target_node']['refid'] \
                         # Gets mostly called during latex generation

--- a/sphinxcontrib/needs/directives/needflow.py
+++ b/sphinxcontrib/needs/directives/needflow.py
@@ -1,7 +1,6 @@
 import html
 import os
 import re
-import urllib
 from typing import Iterable
 
 from docutils import nodes
@@ -20,8 +19,6 @@ from sphinxcontrib.needs.filter_common import (
 from sphinxcontrib.needs.logging import getLogger
 
 logger = getLogger(__name__)
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needflow(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needgantt.py
+++ b/sphinxcontrib/needs/directives/needgantt.py
@@ -1,5 +1,4 @@
 import os
-import urllib
 from datetime import datetime
 
 from docutils import nodes
@@ -27,8 +26,6 @@ from sphinxcontrib.needs.logging import getLogger
 from sphinxcontrib.needs.utils import MONTH_NAMES
 
 logger = getLogger(__name__)
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needgantt(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needlist.py
+++ b/sphinxcontrib/needs/directives/needlist.py
@@ -3,15 +3,11 @@
 
 """
 
-import urllib
-
 from docutils import nodes
 from docutils.parsers.rst import directives
 
 from sphinxcontrib.needs.filter_common import FilterBase, process_filters
 from sphinxcontrib.needs.directives.utils import no_needs_found_paragraph, used_filter_paragraph
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needlist(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needpie.py
+++ b/sphinxcontrib/needs/directives/needpie.py
@@ -1,5 +1,4 @@
 import os
-import urllib
 
 import matplotlib
 from docutils import nodes
@@ -16,8 +15,6 @@ from docutils.parsers.rst import directives
 from sphinxcontrib.needs.logging import getLogger
 
 logger = getLogger(__name__)
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needpie(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needsequence.py
+++ b/sphinxcontrib/needs/directives/needsequence.py
@@ -1,6 +1,5 @@
 import os
 import re
-import urllib
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -20,8 +19,6 @@ from sphinxcontrib.needs.filter_common import FilterBase
 from sphinxcontrib.needs.logging import getLogger
 
 logger = getLogger(__name__)
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needsequence(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/directives/needtable.py
+++ b/sphinxcontrib/needs/directives/needtable.py
@@ -1,4 +1,3 @@
-import urllib
 import re
 
 from docutils import nodes
@@ -7,8 +6,6 @@ from sphinxcontrib.needs.utils import row_col_maker
 from sphinxcontrib.needs.filter_common import FilterBase, process_filters
 from sphinxcontrib.needs.directives.utils import no_needs_found_paragraph, used_filter_paragraph
 from sphinxcontrib.needs.functions.functions import check_and_get_content
-
-urlParse = urllib.parse.quote_plus
 
 
 class Needtable(nodes.General, nodes.Element):

--- a/sphinxcontrib/needs/filter_common.py
+++ b/sphinxcontrib/needs/filter_common.py
@@ -4,16 +4,12 @@ like needtable, needlist and needflow.
 """
 
 import re
-import sys
-import urllib
 import copy
 
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 
 from sphinxcontrib.needs.utils import status_sorter, merge_two_dicts, logger
-
-urlParse = urllib.parse.quote_plus
 
 
 class FilterBase(Directive):


### PR DESCRIPTION
I noticed most of the urlib imports are unused. Also there are two different 'flavours' of `urlparse` used in different places.