### PR TITLE
Using id_complete in filters instead of id only

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ License
   (`#151 <https://github.com/useblocks/sphinxcontrib-needs/issues/151>`_)
 * Bugfix: :ref:`needtable` shows horizontal scrollbar for tables using datatables style.
   (`#271 <https://github.com/useblocks/sphinxcontrib-needs/issues/271>`_)
+* Bugfix: Using ``id_complete`` instead of ``id`` in filter code handling.
+  (`#156 <https://github.com/useblocks/sphinxcontrib-needs/issues/156>`_)
 
 0.6.2
 -----

--- a/sphinxcontrib/needs/filter_common.py
+++ b/sphinxcontrib/needs/filter_common.py
@@ -124,16 +124,16 @@ def process_filters(all_needs, current_needlist):
         found_needs = []
 
         # Just take the ids from search result and use the related, but original need
-        found_need_ids = [x["id"] for x in found_dirty_needs]
+        found_need_ids = [x["id_complete"] for x in found_dirty_needs]
         for need in all_needs_incl_parts:
-            if need["id"] in found_need_ids:
+            if need["id_complete"] in found_need_ids:
                 found_needs.append(need)
 
     # Store basic filter configuration and result global list.
     # Needed mainly for exporting the result to needs.json (if builder "needs" is used).
     env = current_needlist["env"]
     filter_list = env.needs_all_filters
-    found_needs_ids = [need["id"] for need in found_needs]
+    found_needs_ids = [need["id_complete"] for need in found_needs]
 
     filter_list[current_needlist["target_node"]] = {
         "target_node": current_needlist["target_node"],


### PR DESCRIPTION
This respects need_parts much better, as "id"
does not contain the need_part sub-id.

Fixes #156