### PR TITLE
Better needextend calling logic

### DIFF
--- a/sphinxcontrib/needs/directives/needextend.py
+++ b/sphinxcontrib/needs/directives/needextend.py
@@ -61,102 +61,120 @@ def process_needextend(app, doctree, fromdocname):
     Perform all modifications on needs
     """
     env = app.builder.env
-    list_names = (
-        ["tags", "links"]
-        + [x["option"] for x in app.config.needs_extra_links]
-        + [f"{x['option']}_back" for x in app.config.needs_extra_links]
-    )  # back-links (incoming)
-    link_names = [x["option"] for x in app.config.needs_extra_links]
+    if not hasattr(env, "need_all_needextend"):
+        env.need_all_needextend = {}
+
+    if not env.needs_workflow["needs_extended"]:
+        env.needs_workflow["needs_extended"] = True
+
+        list_names = (
+            ["tags", "links"]
+            + [x["option"] for x in app.config.needs_extra_links]
+            + [f"{x['option']}_back" for x in app.config.needs_extra_links]
+        )  # back-links (incoming)
+        link_names = [x["option"] for x in app.config.needs_extra_links]
+
+        for extend_name, current_needextend in env.need_all_needextend.items():
+
+            # Check if filter is just a need-id.
+            # In this case create the needed filter string
+            need_filter = current_needextend["filter"]
+            if need_filter in app.env.needs_all_needs:
+                need_filter = f'id == "{need_filter}"'
+            # If it looks like a need id, but we haven't found one, raise an exception
+            elif re.fullmatch(app.config.needs_id_regex, need_filter):
+                raise NeedsInvalidFilter(f"Provided id {need_filter} for needextend does not exist.")
+
+            try:
+                found_needs = filter_needs(app.env.needs_all_needs.values(), need_filter)
+            except NeedsInvalidFilter as e:
+                raise NeedsInvalidFilter(
+                    f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}"
+                )
+
+            for found_need in found_needs:
+                # Work in the stored needs, not on the search result
+                need = app.env.needs_all_needs[found_need["id"]]
+                need["is_modified"] = True
+                need["modifications"] += 1
+
+                for option, value in current_needextend["modifications"].items():
+                    if option.startswith("+"):
+                        option_name = option[1:]
+
+                        # If we need to handle a list
+                        if option_name in list_names:
+                            for link in re.split(";|,", value):
+                                if link not in need[option_name]:
+                                    need[option_name].append(link)
+
+                            # If we manipulate links, we need to set all the reference in the target need
+                            # under e.g. links_back
+                            if option_name in link_names:
+                                for ref_need in re.split(";|,", value):
+                                    if found_need["id"] not in app.env.needs_all_needs[ref_need][f"{option_name}_back"]:
+                                        app.env.needs_all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
+
+                        # else it must be a normal string
+                        else:
+                            # If content is already stored, we need to add some whitespace
+                            if need[option_name]:
+                                need[option_name] += " "
+                            need[option_name] += value
+                    elif option.startswith("-"):
+                        option_name = option[1:]
+                        if option_name in list_names:
+                            old_content = need[option_name]  # Save it, as it may be need to identify referenced needs
+                            need[option_name] = []
+
+                            # If we manipulate links, we need to delete the reference in the target need as well
+                            if option_name in link_names:
+                                for ref_need in old_content:  # There may be several links
+                                    app.env.needs_all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
+
+                        else:
+                            need[option_name] = ""
+                    else:
+                        if option in list_names:
+                            old_content = need[option].copy()
+
+                            need[option] = []
+                            for link in re.split(";|,", value):
+                                if link not in need[option]:
+                                    need[option].append(link)
+
+                            # If add new links also as "link_s_back" to the referenced need.
+                            if option in link_names:
+                                # Remove old links
+                                for ref_need in old_content:  # There may be several links
+                                    app.env.needs_all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
+
+                                # Add new links
+                                for ref_need in need[option]:  # There may be several links
+                                    if found_need["id"] not in app.env.needs_all_needs[ref_need][f"{option}_back"]:
+                                        app.env.needs_all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
+
+                        else:
+                            need[option] = value
 
     for node in doctree.traverse(Needextend):
-        id = node.attributes["ids"][0]
-        current_needextend = env.need_all_needextend[id]
+        # No printouts for needextend
+        removed_needextend_node(node)
 
-        # Check if filter is just a need-id.
-        # In this case create the needed filter string
-        need_filter = current_needextend["filter"]
-        if need_filter in app.env.needs_all_needs:
-            need_filter = f'id == "{need_filter}"'
-        # If it looks like a need id, but we haven't found one, raise an exception
-        elif re.fullmatch(app.config.needs_id_regex, need_filter):
-            raise NeedsInvalidFilter(f"Provided id {need_filter} for needextend does not exist.")
 
-        try:
-            found_needs = filter_needs(app.env.needs_all_needs.values(), need_filter)
-        except NeedsInvalidFilter as e:
-            raise NeedsInvalidFilter(f"Filter not valid for needextend on page {current_needextend['docname']}:\n{e}")
+def removed_needextend_node(node):
+    """
+    # Remove needextend from docutils node-tree, so that no output gets generated for it.
+    # Ok, this is really dirty.
+    # If we replace a node, docutils checks, if it will not lose any attributes.
+    # But this is here the case, because we are using the attribute "ids" of a node.
+    # However, I do not understand, why losing an attribute is such a big deal, so we delete everything
+    # before docutils claims about it.
 
-        for found_need in found_needs:
-            # Work in the stored needs, not on the search result
-            need = app.env.needs_all_needs[found_need["id"]]
-            need["is_modified"] = True
-            need["modifications"] += 1
+    :param node:
+    :return:
+    """
 
-            for option, value in current_needextend["modifications"].items():
-                if option.startswith("+"):
-                    option_name = option[1:]
-
-                    # If we need to handle a list
-                    if option_name in list_names:
-                        for link in re.split(";|,", value):
-                            if link not in need[option_name]:
-                                need[option_name].append(link)
-
-                        # If we manipulate links, we need to set all the reference in the target need
-                        # under e.g. links_back
-                        if option_name in link_names:
-                            for ref_need in re.split(";|,", value):
-                                if found_need["id"] not in app.env.needs_all_needs[ref_need][f"{option_name}_back"]:
-                                    app.env.needs_all_needs[ref_need][f"{option_name}_back"] += [found_need["id"]]
-
-                    # else it must be a normal string
-                    else:
-                        # If content is already stored, we need to add some whitespace
-                        if need[option_name]:
-                            need[option_name] += " "
-                        need[option_name] += value
-                elif option.startswith("-"):
-                    option_name = option[1:]
-                    if option_name in list_names:
-                        old_content = need[option_name]  # Save it, as it may be need to identify referenced needs
-                        need[option_name] = []
-
-                        # If we manipulate links, we need to delete the reference in the target need as well
-                        if option_name in link_names:
-                            for ref_need in old_content:  # There may be several links
-                                app.env.needs_all_needs[ref_need][f"{option_name}_back"].remove(found_need["id"])
-
-                    else:
-                        need[option_name] = ""
-                else:
-                    if option in list_names:
-                        old_content = need[option].copy()
-
-                        need[option] = []
-                        for link in re.split(";|,", value):
-                            if link not in need[option]:
-                                need[option].append(link)
-
-                        # If add new links also as "link_s_back" to the referenced need.
-                        if option in link_names:
-                            # Remove old links
-                            for ref_need in old_content:  # There may be several links
-                                app.env.needs_all_needs[ref_need][f"{option}_back"].remove(found_need["id"])
-
-                            # Add new links
-                            for ref_need in need[option]:  # There may be several links
-                                if found_need["id"] not in app.env.needs_all_needs[ref_need][f"{option}_back"]:
-                                    app.env.needs_all_needs[ref_need][f"{option}_back"] += [found_need["id"]]
-
-                    else:
-                        need[option] = value
-
-        # Remove needextend from docutils node-tree, so that no output gets generated for it.
-        # Ok, this is really dirty.
-        # If we replace a node, docutils checks, if it will not lose any attributes.
-        # But this is here the case, because we are using the attribute "ids" of a node.
-        # However, I do not understand, why losing an attribute is such a big deal, so we delete everything
-        # before docutils claims about it.
-        for att in ("ids", "names", "classes", "dupnames"):
-            node[att] = []
-        node.replace_self([])
+    for att in ("ids", "names", "classes", "dupnames"):
+        node[att] = []
+    node.replace_self([])

--- a/sphinxcontrib/needs/needs.py
+++ b/sphinxcontrib/needs/needs.py
@@ -476,7 +476,11 @@ def prepare_env(app, env, _docname):
         # Some tasks like backlink_creation need be be performed only once.
         # But most sphinx-events get called several times (for each single document
         # file), which would also execute our code several times...
-        env.needs_workflow = {"backlink_creation_links": False, "dynamic_values_resolved": False}
+        env.needs_workflow = {
+            "backlink_creation_links": False,
+            "dynamic_values_resolved": False,
+            "needs_extended": False,
+        }
         for link_type in app.config.needs_extra_links:
             env.needs_workflow["backlink_creation_{}".format(link_type["option"])] = False
 

--- a/tests/doc_test/doc_needextend/index.rst
+++ b/tests/doc_test/doc_needextend/index.rst
@@ -1,6 +1,11 @@
 Need extend
 ===========
 
+.. toctree::
+
+   page_1
+   page_2
+
 .. story:: needextend Example 3
    :id: extend_test_003
 

--- a/tests/doc_test/doc_needextend/page_1.rst
+++ b/tests/doc_test/doc_needextend/page_1.rst
@@ -1,0 +1,12 @@
+need objects
+============
+
+
+.. story:: needextend different pages test
+   :id: extend_test_page
+   :status: open
+   :tags: tag_1
+
+.. needextend:: extend_test_page
+   :status: closed
+

--- a/tests/doc_test/doc_needextend/page_2.rst
+++ b/tests/doc_test/doc_needextend/page_2.rst
@@ -1,0 +1,6 @@
+need extend
+===========
+
+.. needextend:: extend_test_page
+   :+tags: new_tag, another_tag
+

--- a/tests/test_needextend.py
+++ b/tests/test_needextend.py
@@ -6,16 +6,23 @@ from sphinx_testing import with_app
 @with_app(buildername="html", srcdir="doc_test/doc_needextend")
 def test_doc_needextend_html(app, status, warning):
     app.build()
-    html = Path(app.outdir, "index.html").read_text()
-    assert "extend_test_003" in html
+    index_html = Path(app.outdir, "index.html").read_text()
+    assert "extend_test_003" in index_html
 
     assert (
         '<div class="line">links outgoing: <span class="links"><span><a class="reference internal" href="#extend_'
-        'test_004" title="extend_test_003">extend_test_004</a></span></span></div>' in html
+        'test_004" title="extend_test_003">extend_test_004</a></span></span></div>' in index_html
     )
 
     assert (
         '<div class="line">links outgoing: <span class="links"><span><a class="reference internal" href="#extend_'
         'test_003" title="extend_test_006">extend_test_003</a>, <a class="reference internal" href="#extend_'
-        'test_004" title="extend_test_006">extend_test_004</a></span></span></div>' in html
+        'test_004" title="extend_test_006">extend_test_004</a></span></span></div>' in index_html
+    )
+
+    page_1__html = Path(app.outdir, "page_1.html").read_text()
+    assert (
+        '<span class="needs_data_container"><span class="needs_data">tag_1</span><span class="needs_spacer">, '
+        '</span><span class="needs_data">new_tag</span><span class="needs_spacer">, '
+        '</span><span class="needs_data"> another_tag</span></span>' in page_1__html
     )


### PR DESCRIPTION
Add needextend directives get now handled
once and all together, before any final
need print out starts.

So no doctree.traverse() is used, except for
removing needextend-node from doctree.

Fixes #310