### PR TITLE
Fix 458

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,8 @@ License
   (`#457 <https://github.com/useblocks/sphinxcontrib-needs/issues/457>`_)
 * Bugfix: Changed :ref:`needs_external_needs` Fix issue when loading needs from URL.
   (`#459 <https://github.com/useblocks/sphinxcontrib-needs/issues/459>`_)
-
+* Bugfix: Changed :ref:`needs_external_needs` getting from URL was using parameter related to local file.
+  (`#458 <https://github.com/useblocks/sphinxcontrib-needs/issues/458>`_)
 
 0.7.4
 -----

--- a/sphinxcontrib/needs/external_needs.py
+++ b/sphinxcontrib/needs/external_needs.py
@@ -31,7 +31,6 @@ def load_external_needs(app, env, _docname):
             log.info(f'Loading external needs from url {source["json_url"]}')
             s = requests.Session()
             s.mount("file://", FileAdapter())
-            log.info(f'Loading external needs from local file {source["json_path"]}')
             try:
                 response = s.get(source["json_url"])
                 needs_json = response.json()  # The downloaded file MUST be json. Everything else we do not handle!

--- a/tests/doc_test/doc_needs_external_needs_remote/conf.py
+++ b/tests/doc_test/doc_needs_external_needs_remote/conf.py
@@ -46,11 +46,9 @@ plantuml = "java -jar %s" % os.path.join(os.path.dirname(__file__), "..", "..", 
 plantuml_output_format = "svg"
 
 needs_external_needs = [
-    # add an empty json_path value, else failure. See ticket 458.
     {
         "base_url": "http://my_company.com/docs/v1/",
         "json_url": "http://my_company.com/docs/v1/remote-needs.json",
-        "json_path": "",
         "id_prefix": "ext_remote_",
     },
 ]

--- a/tests/test_needs_external_needs_build.py
+++ b/tests/test_needs_external_needs_build.py
@@ -12,7 +12,7 @@ def test_doc_build_html(app, status, warning):
     src_dir = "doc_test/doc_needs_external_needs"
     out_dir = Path(app.outdir)
     output = subprocess.run(["sphinx-build", "-M", "html", src_dir, out_dir], capture_output=True)
-    assert not output.stderr
+    assert not output.stderr, f"Should not have stderr: {output.stderr}"
 
     # run second time and check
     output_second = subprocess.run(["sphinx-build", "-M", "html", src_dir, out_dir], capture_output=True)


### PR DESCRIPTION
This PR fix an issue happening when using _json_url_ for external needs access.
In this case, some logging is called on _json_path_ value which is not required (thus may not be defined) causing a failure (KeyError).