### PR TITLE
Fix references in needtables when building with rinohtype

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,5 @@ Baran Barış Yıldızlı <arisbbyil@gmail.com>
 Roberto Rötting <roberto.roetting@gmail.com>
 
 Nirmal Sasidharan <nirmal.sasidharan@de.bosch.com>
+
+Jacob Allen <jacob.allen@etas.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ License
 
 * Bugfix: Support embedded needs in embedded needs.
   (`#486 <https://github.com/useblocks/sphinxcontrib-needs/issues/486>`_)
+* Bugfix: Correct references in :ref:`needtable`s to be external or internal instead of always external.
 
 0.7.9
 -----

--- a/sphinxcontrib/needs/utils.py
+++ b/sphinxcontrib/needs/utils.py
@@ -113,7 +113,14 @@ def row_col_maker(
             text_col = nodes.Text(datum_text, datum_text)
             if make_ref or ref_lookup:
                 try:
-                    ref_col = nodes.reference("", "")
+                    if need_info["is_external"]:
+                        ref_col = nodes.reference("", "")
+                    else:
+                        # Mark reference as "internal" so that if the rinohtype builder is being used it produces an
+                        # internal reference within the generated PDF instead of an external link. This replicates the
+                        # behaviour of references created with the sphinx utility `make_refnode`.
+                        ref_col = nodes.reference("", "", internal=True)
+
                     if make_ref:
                         if need_info["is_external"]:
                             ref_col["refuri"] = check_and_calc_base_url_rel_path(need_info["external_url"], fromdocname)

--- a/tests/test_needs_filter_data.py
+++ b/tests/test_needs_filter_data.py
@@ -79,4 +79,4 @@ def test_doc_needs_filter_code(test_app):
     assert '<img alt="_images/need_pie_' in code_html
 
     code_args_html = Path(app.outdir, "filter_code_args.html").read_text()
-    assert '<a class="reference external" href="#impl1">impl1</a>' in code_args_html
+    assert '<a class="reference internal" href="#impl1">impl1</a>' in code_args_html


### PR DESCRIPTION
While using Sphinx-Needs with a [rinohtype](https://github.com/brechtm/rinohtype)-based builder I discovered that links in needtables did not link properly inside the generated PDF while links in need definitions did. It seems this is caused by references in needtables being created without the `internal=True` attribute which is added to most other references automatically becuase they are created using the `make_refnode` utility ([defined here](https://github.com/sphinx-doc/sphinx/blob/31eba1a76dd485dc633cae48227b46879eda5df4/sphinx/util/nodes.py#L552)).

This change simply adds the `internal=True` attribute to needtable references if they are not marked as external. This means that needtables will build properly with the rinohtype builder (and possibly other builders which rely on the `internal` attribute) and should not affect other builders negatively.