### PR TITLE
set up mypy hook for incremental adoption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,13 @@ repos:
       - id: pyupgrade
         args:
           - --py36-plus
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.950
+    hooks:
+      - id: mypy
+        pass_filenames: false
+        additional_dependencies:
+          - types-requests==2.27.25
+          - types-setuptools==57.4.14
+          - types-docutils==0.18.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,34 @@ line-length = 120
 [tool.isort]
 profile = "black"
 
+[tool.mypy]
+strict = true
+show_error_codes = true
+files = "sphinxcontrib"
+
+[[tool.mypy.overrides]]
+module = [
+  'sphinxcontrib.needs.api.*',
+  'sphinxcontrib.needs.builder.*',
+  'sphinxcontrib.needs.config.*',
+  'sphinxcontrib.needs.diagrams_common.*',
+  'sphinxcontrib.needs.directives.*',
+  'sphinxcontrib.needs.environment.*',
+  'sphinxcontrib.needs.external_needs.*',
+  'sphinxcontrib.needs.filter_common.*',
+  'sphinxcontrib.needs.functions.*',
+  'sphinxcontrib.needs.layout.*',
+  'sphinxcontrib.needs.logging.*',
+  'sphinxcontrib.needs.needs.*',
+  'sphinxcontrib.needs.needsfile.*',
+  'sphinxcontrib.needs.nodes.*',
+  'sphinxcontrib.needs.roles.*',
+  'sphinxcontrib.needs.services.*',
+  'sphinxcontrib.needs.utils.*',
+  'sphinxcontrib.needs.warnings.*',
+]
+ignore_errors = true
+
 [tool.poetry.extras]
 docs = ["sphinx>=4.0"]
 

--- a/sphinxcontrib/needs/builder.py
+++ b/sphinxcontrib/needs/builder.py
@@ -61,13 +61,13 @@ class NeedsBuilder(Builder):
         yield
         # return ""
 
-    def prepare_writing(self, docnames):
+    def prepare_writing(self, docnames) -> None:
         pass
 
-    def write_doc_serialized(self, docname, doctree):
+    def write_doc_serialized(self, docname, doctree) -> None:
         pass
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         pass
 
     def get_target_uri(self, docname, typ=None):

--- a/sphinxcontrib/needs/config.py
+++ b/sphinxcontrib/needs/config.py
@@ -8,7 +8,7 @@ class Config:
     So this Config class somehow collects possible configurations and stores it in a save way.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.configs = {}
 
     def add(self, name, value, option_type=str, append=False, overwrite=False):


### PR DESCRIPTION
this pull request sets up mypy to allow for incremental adoption of type annotations.

it does this by adding a 'mypy' pre-commit hook, and a 'whitelist' to the `pyproject.toml` file such that all the existing errors are ignored. Over time, this whitelist can be reduced as modules are incrementally 'typed'. New modules should be fully-typed.