### PR TITLE
use python 3.10 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         os: ["ubuntu-latest"]
         # 3.9.8 seems to be broken with type_ast
         # https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1829077.html
-        python-version: ["3.6", "3.8", "3.9.7"]
+        python-version: ["3.6", "3.8", "3.9", "3.10"]
 
         sphinx-version: ["3.2", '3.5.4', '4.1', '4.2']
         exclude:
@@ -19,7 +19,7 @@ jobs:
         include:
           # Check only newest setups for win server
           - os: "windows-latest"
-            python-version: "3.9.7"
+            python-version: "3.10"
             sphinx-version: "4.2"
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: pre-commit/action@v2.0.3
 
   linkcheck:
@@ -61,7 +61,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install Nox Dependencies
         run: |
           python -m pip install poetry nox nox-poetry pyparsing==3.0.4

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 from nox_poetry import session
 
-PYTHON_VERSIONS = ["3.6", "3.8", "3.9.7"]
+PYTHON_VERSIONS = ["3.6", "3.8", "3.9", "3.10"]
 SPHINX_VERSIONS = ["3.2", "3.5.4", "4.1", "4.2"]
 TEST_DEPENDENCIES = [
     "pytest",


### PR DESCRIPTION
As you can see, the specified version of `numpy` fails to build with Python 3.10