### PR TITLE
fix poetry lock file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,11 @@ repos:
         language: system
         require_serial: true
         pass_filenames: false
+
+  - repo: https://github.com/python-poetry/poetry
+    rev: 1.2.0b1
+    hooks:
+      - id: poetry-check
+      - id: poetry-lock
+        args:
+          - --no-update


### PR DESCRIPTION
I noticed that the poetry lock file was not quite aligned with the pyproject.toml file.

This PR fixes that misalignment, and adds a pre-commit hook to prevent it from happening again