### PR TITLE
only run 'links check' job if docs/ is changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,18 +51,3 @@ jobs:
         with:
           python-version: "3.9"
       - uses: pre-commit/action@v2.0.3
-
-  linkcheck:
-    name: Docs-Linkcheck
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set Up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.9"
-      - name: Install Nox Dependencies
-        run: |
-          python -m pip install poetry nox nox-poetry pyparsing==3.0.4
-      - name: Run LinkCheck
-        run: nox --non-interactive --session linkcheck -- --full-trace

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request:
+    paths: [docs/**]
+jobs:
+  linkcheck:
+    name: Docs-Linkcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install Nox Dependencies
+        run: |
+          python -m pip install poetry nox nox-poetry pyparsing==3.0.4
+      - name: Run LinkCheck
+        run: nox --non-interactive --session linkcheck -- --full-trace


### PR DESCRIPTION
changes the 'links check' job to only trigger if there are changes in the `docs/` directory.

This won't pass while this is an 'expected' check