### PR TITLE
Add docu for needextend default option values

### DIFF
--- a/docs/directives/needextend.rst
+++ b/docs/directives/needextend.rst
@@ -102,6 +102,22 @@ If only one single need shall get modified, the argument of ``needextend`` can j
     :ref:`needs_id_regex` and a need with this ID must exist!
     Otherwise the argument is taken as normal filter string.
 
+Setting default option values
+-----------------------------
+You can use ``needextend``'s filter string to set default option values for a group of needs.
+
+|ex|
+
+The following example would set the status of all needs in the document
+``docs/directives/needextend.rst``, which do not have the status set explicitly, to ``open``.
+
+.. code-block:: rst
+
+   .. needextend:: (docname == "docs/directives/needextend") and (status is None)
+      :status: open
+
+See also: :ref:`needs_global_options` for setting a default option value for all needs.
+
 Changing links
 --------------
 Options containing links get handled in two steps:

--- a/docs/filter.rst
+++ b/docs/filter.rst
@@ -20,6 +20,7 @@ The following filter options are supported by directives:
  * :ref:`needflow`
  * :ref:`needpie`
  * :ref:`needfilter` (deprecated!)
+ * :ref:`needextend`
 
 
 Related to the used directive and its representation, the filter options create a list of needs, which match the
@@ -195,6 +196,7 @@ Inside a filter string the following variables/functions can be used:
 * **needs** as Python dict. Contains all needs. Helpful to perform complex filters on links (added 0.3.15).
 * **sections** as list of sections names, th which the need belongs to.
 * **section_name** as string, which defines the last/lowest section a need belongs to.
+* **docname** as string, which defines the name of the document in which a need is defined, without the extension (similar to Sphinx' ``:doc:`` role)
 * **signature** as string, which contains a function-name, possible set by
   `sphinx-autodoc <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ above the need.
 * **parent_need** as string, which is an id of the need, which has the current need defined in its content


### PR DESCRIPTION
resolves useblocks/sphinxcontrib-needs#313

@danwos: I also documented the "docname" option now, as the use case will often require using it. Needextend was also prominently missing from the "list of directives that support filters" ;-)