### PR TITLE
updated changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ Under development
   (`#498 <https://github.com/useblocks/sphinxcontrib-needs/issues/498>`_)
 * Improvement: Added `show_top_sum` to :ref:`Needbar <needbar>` and make it possible to rotate the bar labels.
   (`#516 <https://github.com/useblocks/sphinxcontrib-needs/issues/516>`_)
+* Improvement: Added `needs_constraints` option. Constraints can be set for individual needs and describe properties
+  a need has to meet.
 
 0.7.9
 -----

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1706,6 +1706,8 @@ Default value: ``needs.json``
 needs_constraints
 ~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 1.0.1
+
 .. code-block:: python
 
     needs_constraints = {


### PR DESCRIPTION
sanity check on formatting. my buildprocess is breaking on

```
.venv/lib/python3.10/site-packages/sphinx_immaterial/object_toc.py", line 33, in _make_section_from_desc
    for child in source._traverse():
AttributeError: 'desc' object has no attribute '_traverse'
```
can't check myself