### PR TITLE
update poetry.lock file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,3 @@ repos:
     rev: 1.2.0b1
     hooks:
       - id: poetry-check
-      - id: poetry-lock
-        args:
-          - --no-update


### PR DESCRIPTION
Hi @danwos there's a pre-commit hook to ensure that the lock file stays up to date with the pyproject.toml file. One of the recent commits has failed to keep the lock file up to date, which is why the CI is failing on a few PRs.

This PR fixes that. If you merge this and rebase, the PRs should be good again

EDIT: scratch that. it's due to different versions of Poetry locally and in CI. I'll just remove this check instead